### PR TITLE
Remove 4.10 from the multicore compiler test list, as unused now

### DIFF
--- a/service/conf.ml
+++ b/service/conf.ml
@@ -101,7 +101,7 @@ let platforms =
         List.map make_release ovs @ [make_release ~arch:`I386 (List.hd ovs)]
     end
   | `Multicore ->
-    let ovs = List.map OV.of_string_exn ["4.10+multicore"; "4.12"; "4.12+domains"; "4.12+domains+effects"] in
+    let ovs = List.map OV.of_string_exn ["4.12"; "4.12+domains"; "4.12+domains+effects"] in
     List.map make_release ovs
 
 let opam_repository_repos = [


### PR DESCRIPTION
All development for multicore is on either 4.12 or 5.x preview
branches now.

Signed-off-by: Anil Madhavapeddy <anil@recoil.org>