### PR TITLE
update irmin version from 2.7 to 2.9

### DIFF
--- a/service/conf.ml
+++ b/service/conf.ml
@@ -127,7 +127,7 @@ let fixed_repos = [
   "https://github.com/janestreet/base@v0.14.1";
   "https://github.com/janestreet/core@v0.14.1";
   "https://github.com/janestreet/core_kernel@v0.14.1";
-  "https://github.com/mirage/irmin@2.7";
+  "https://github.com/mirage/irmin@2.9.0";
   "https://github.com/ocaml-batteries-team/batteries-included@v3.3.0";
   "https://github.com/ocaml-multicore/ocaml-multicore@4.12+domains";
   "https://github.com/ocaml-multicore/tezos@5963aae437809881f67aee3373e5d35b5aa2348f";


### PR DESCRIPTION
Irmin 2.7 use a deprecated "Fmt" module version https://github.com/mirage/irmin/pull/1538