### PR TITLE
fix Tezos build+test Cancel cause by timeout

### DIFF
--- a/service/pipeline.ml
+++ b/service/pipeline.ml
@@ -236,7 +236,7 @@ let build_from_clone ?ocluster ~solver (repo_clone: (string * Git.Commit.t Curre
     Current.ignore_value build
 
 let v ?ocluster ~solver () =
-  let ocluster = Option.map (Cluster_build.config ~timeout:(Duration.of_hour 2)) ocluster in
+  let ocluster = Option.map (Cluster_build.config ~timeout:(Duration.of_hour 7)) ocluster in
   Current.with_context opam_repository_commits @@ fun () ->
   Current.with_context platforms @@ fun () ->
   let build_fixed =


### PR DESCRIPTION
the timeout in the file [service/config.ml](https://github.com/ocurrent/ocaml-multicore-ci/blob/3eca82f3edf79c6e7862f81427bc8e486c0801b4/service/conf.ml#L36) not use yet in the pipeline