### PR TITLE
Add dependency installation steps in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,12 @@ Note: you need to clone with `--recursive` because this project uses submodules
 (it depends on some packages that aren't released yet).
 If you forget, `git submodule update --init` will fetch them.
 
-To test the CI on a local Git clone, use:
+To test the CI on a local Git clone, you need to first install the
+dependencies, and then use `dune exec` as shown below:
 
 ```sh
+opam update
+opam install -t .
 dune exec -- ocaml-multicore-ci-local /path/to/project
 ```
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ dependencies, and then use `dune exec` as shown below:
 
 ```sh
 opam update
-opam install -t .
+opam install . --deps-only --yes --with-test
 dune exec -- ocaml-multicore-ci-local /path/to/project
 ```
 


### PR DESCRIPTION
For testing a local project, `opam update` and the dependency installation steps are required. The same have been added to the README.