### PR TITLE
Solver as a service with solver-service

### DIFF
--- a/api/build.capnp
+++ b/api/build.capnp
@@ -88,11 +88,3 @@ interface CI {
   jobs         @2 () -> (jobs :List(JobInfo));
   # Get the list of active jobs.
 }
-
-interface Log {
-  write @0 (msg :Text);
-}
-
-interface Solver {
-  solve @0 (request :Text, log :Log) -> (response :Text);
-}

--- a/api/client.ml
+++ b/api/client.ml
@@ -7,7 +7,7 @@ type variant = string
 module Ref_map = Map.Make(String)
 
 module State = struct
-  open Raw.Reader.JobInfo.State
+  open Raw.Build.Reader.JobInfo.State
 
   type t = unnamed_union_t
 
@@ -22,7 +22,7 @@ module State = struct
 end
 
 module Build_status = struct
-  include Raw.Reader.BuildStatus
+  include Raw.Build.Reader.BuildStatus
 
   let pp f =
     function
@@ -43,32 +43,32 @@ type job_info = {
 }
 
 let raw_job_to_job_info job =
-  let owner = Raw.Reader.JobInfo.owner_get job in
-  let name = Raw.Reader.JobInfo.name_get job in
-  let hash = Raw.Reader.JobInfo.hash_get job in
-  let job_id = Raw.Reader.JobInfo.job_id_get job in
-  let variant = Raw.Reader.JobInfo.variant_get job in
-  let state = Raw.Reader.JobInfo.state_get job in
-  let outcome = Raw.Reader.JobInfo.State.get state in
+  let owner = Raw.Build.Reader.JobInfo.owner_get job in
+  let name = Raw.Build.Reader.JobInfo.name_get job in
+  let hash = Raw.Build.Reader.JobInfo.hash_get job in
+  let job_id = Raw.Build.Reader.JobInfo.job_id_get job in
+  let variant = Raw.Build.Reader.JobInfo.variant_get job in
+  let state = Raw.Build.Reader.JobInfo.state_get job in
+  let outcome = Raw.Build.Reader.JobInfo.State.get state in
   { owner; name; hash; job_id; variant; outcome }
 
 module CI = struct
-  type t = Raw.Client.CI.t Capability.t
+  type t = Raw.Build.Client.CI.t Capability.t
 
   let org t owner =
-    let open Raw.Client.CI.Org in
+    let open Raw.Build.Client.CI.Org in
     let request, params = Capability.Request.create Params.init_pointer in
     Params.owner_set params owner;
     Capability.call_for_caps t method_id request Results.org_get_pipelined
 
   let orgs t =
-    let open Raw.Client.CI.Orgs in
+    let open Raw.Build.Client.CI.Orgs in
     let request = Capability.Request.create_no_args () in
     Capability.call_for_value t method_id request
     |> Lwt_result.map Results.orgs_get_list
 
   let jobs t =
-    let open Raw.Client.CI.Jobs in
+    let open Raw.Build.Client.CI.Jobs in
     let request = Capability.Request.create_no_args () in
     Capability.call_for_value t method_id request
     |> Lwt_result.map @@ fun jobs ->
@@ -76,7 +76,7 @@ module CI = struct
 end
 
 module Org = struct
-  type t = Raw.Client.Org.t Capability.t
+  type t = Raw.Build.Client.Org.t Capability.t
 
   type repo_info = {
     name : string;
@@ -84,70 +84,70 @@ module Org = struct
   }
 
   let repo t name =
-    let open Raw.Client.Org.Repo in
+    let open Raw.Build.Client.Org.Repo in
     let request, params = Capability.Request.create Params.init_pointer in
     Params.name_set params name;
     Capability.call_for_caps t method_id request Results.repo_get_pipelined
 
   let repos t =
-    let open Raw.Client.Org.Repos in
+    let open Raw.Build.Client.Org.Repos in
     let request = Capability.Request.create_no_args () in
     Capability.call_for_value t method_id request
     |> Lwt_result.map (fun result ->
         Results.repos_get_list result
         |> List.map @@ fun repo ->
-        let name = Raw.Reader.RepoInfo.name_get repo in
-        let master_status = Raw.Reader.RepoInfo.master_state_get repo in
+        let name = Raw.Build.Reader.RepoInfo.name_get repo in
+        let master_status = Raw.Build.Reader.RepoInfo.master_state_get repo in
         { name; master_status }
       )
 end
 
 module Repo = struct
-  type t = Raw.Client.Repo.t Capability.t
+  type t = Raw.Build.Client.Repo.t Capability.t
 
   let refs t =
-    let open Raw.Client.Repo.Refs in
+    let open Raw.Build.Client.Repo.Refs in
     let request = Capability.Request.create_no_args () in
     Capability.call_for_value t method_id request |> Lwt_result.map @@ fun jobs ->
     Results.refs_get_list jobs
     |> List.fold_left (fun acc slot ->
-        let gref = Raw.Reader.RefInfo.ref_get slot in
-        let hash = Raw.Reader.RefInfo.hash_get slot in
-        let state = Raw.Reader.RefInfo.state_get slot in
+        let gref = Raw.Build.Reader.RefInfo.ref_get slot in
+        let hash = Raw.Build.Reader.RefInfo.hash_get slot in
+        let state = Raw.Build.Reader.RefInfo.state_get slot in
         Ref_map.add gref (hash, state) acc
       ) Ref_map.empty
 
   let commit_of_hash t hash =
-    let open Raw.Client.Repo.CommitOfHash in
+    let open Raw.Build.Client.Repo.CommitOfHash in
     let request, params = Capability.Request.create Params.init_pointer in
     Params.hash_set params hash;
     Capability.call_for_caps t method_id request Results.commit_get_pipelined
 
   let commit_of_ref t gref =
-    let open Raw.Client.Repo.CommitOfRef in
+    let open Raw.Build.Client.Repo.CommitOfRef in
     let request, params = Capability.Request.create Params.init_pointer in
     Params.ref_set params gref;
     Capability.call_for_caps t method_id request Results.commit_get_pipelined
 end
 
 module Commit = struct
-  type t = Raw.Client.Commit.t Capability.t
+  type t = Raw.Build.Client.Commit.t Capability.t
 
   let job_of_variant t variant =
-    let open Raw.Client.Commit.JobOfVariant in
+    let open Raw.Build.Client.Commit.JobOfVariant in
     let request, params = Capability.Request.create Params.init_pointer in
     Params.variant_set params variant;
     Capability.call_for_caps t method_id request Results.job_get_pipelined
 
   let jobs t =
-    let open Raw.Client.Commit.Jobs in
+    let open Raw.Build.Client.Commit.Jobs in
     let request = Capability.Request.create_no_args () in
     Capability.call_for_value t method_id request
     |> Lwt_result.map @@ fun jobs ->
     Results.jobs_get_list jobs |> List.map raw_job_to_job_info
 
   let refs t =
-    let open Raw.Client.Commit.Refs in
+    let open Raw.Build.Client.Commit.Refs in
     let request = Capability.Request.create_no_args () in
     Capability.call_for_value t method_id request |> Lwt_result.map Results.refs_get_list
 
@@ -156,7 +156,7 @@ module Commit = struct
   let (>>=) = Lwt_result.bind_result
 
   let status t =
-    let open Raw.Client.Commit.Status in
+    let open Raw.Build.Client.Commit.Status in
     let request = Capability.Request.create_no_args () in
     Capability.call_for_value t method_id request
     >>= (Results.status_get

--- a/api/client.mli
+++ b/api/client.mli
@@ -10,13 +10,13 @@ type variant = string
 module Ref_map : Map.S with type key = git_ref
 
 module Build_status : sig
-  type t = Raw.Reader.BuildStatus.t
+  type t = Raw.Build.Reader.BuildStatus.t
 
   val pp : t Fmt.t
 end
 
 module State : sig
-  type t = Raw.Reader.JobInfo.State.unnamed_union_t
+  type t = Raw.Build.Reader.JobInfo.State.unnamed_union_t
 
   val pp : t Fmt.t
 end
@@ -31,7 +31,7 @@ type job_info = {
 }
 
 module Commit : sig
-  type t = Raw.Client.Commit.t Capability.t
+  type t = Raw.Build.Client.Commit.t Capability.t
   (** A single commit being tested. *)
 
   val jobs : t -> (job_info list, [> `Capnp of Capnp_rpc.Error.t ]) Lwt_result.t
@@ -47,7 +47,7 @@ module Commit : sig
 end
 
 module Repo : sig
-  type t = Raw.Client.Repo.t Capability.t
+  type t = Raw.Build.Client.Repo.t Capability.t
   (** A GitHub repository that is tested by ocaml-ci. *)
 
   val refs : t -> ((git_hash * Build_status.t) Ref_map.t, [> `Capnp of Capnp_rpc.Error.t ]) Lwt_result.t
@@ -62,7 +62,7 @@ module Repo : sig
 end
 
 module Org : sig
-  type t = Raw.Client.Org.t Capability.t
+  type t = Raw.Build.Client.Org.t Capability.t
   (** A GitHub organisation. *)
 
   type repo_info = {
@@ -78,7 +78,7 @@ module Org : sig
 end
 
 module CI : sig
-  type t = Raw.Client.CI.t Capability.t
+  type t = Raw.Build.Client.CI.t Capability.t
   (** The top-level object for ocaml-ci. *)
 
   val org : t -> string -> Org.t

--- a/api/dune
+++ b/api/dune
@@ -6,6 +6,6 @@
   (preprocess (pps ppx_deriving.std ppx_deriving_yojson)))
 
 (rule
- (targets schema.ml schema.mli ocurrent.ml ocurrent.mli)
- (deps schema.capnp ocurrent.capnp)
+ (targets solve.ml solve.mli build.ml build.mli ocurrent.ml ocurrent.mli)
+ (deps build.capnp solve.capnp ocurrent.capnp)
  (action (run capnp compile -o %{bin:capnpc-ocaml} %{deps})))

--- a/api/raw.ml
+++ b/api/raw.ml
@@ -1,1 +1,2 @@
-include Schema.MakeRPC(Capnp_rpc_lwt)
+module Build =  Build.MakeRPC(Capnp_rpc_lwt)
+module Solve =  Solve.MakeRPC(Capnp_rpc_lwt)

--- a/api/solve.capnp
+++ b/api/solve.capnp
@@ -1,0 +1,9 @@
+@0x8f8a99339e493464;
+
+interface Log {
+  write @0 (msg :Text);
+}
+
+interface Solver {
+  solve @0 (request :Text, log :Log) -> (response :Text);
+}

--- a/api/solver.ml
+++ b/api/solver.ml
@@ -2,7 +2,7 @@ open Lwt.Infix
 open Capnp_rpc_lwt
 
 module Log = struct
-  module X = Raw.Client.Log
+  module X = Raw.Solve.Client.Log
   type t = X.t Capability.t
 
   let pp_timestamp f x =
@@ -27,7 +27,7 @@ module Log = struct
     Fmt.kstr k ("%a [INFO] @[" ^^ fmt ^^ "@]@.") pp_timestamp now
 end
 
-module X = Raw.Client.Solver
+module X = Raw.Solve.Client.Solver
 
 type t = X.t Capability.t
 

--- a/api/worker.ml
+++ b/api/worker.ml
@@ -10,6 +10,7 @@ module Vars = struct
     os_version : string;
     ocaml_package : string;
     ocaml_version : string;
+    opam_version : string;
   } [@@deriving yojson]
 end
 

--- a/lib/analyse.ml
+++ b/lib/analyse.ml
@@ -342,7 +342,7 @@ module Analysis = struct
       Lwt_result.return r
     )
 
-    let of_dir_sandmark ~job ~platforms ~opam_repository_commits ~package_name ?is_compiler ?compiler_commit () =
+  let of_dir_sandmark ~job ~platforms ~opam_repository_commits ~package_name ?is_compiler ?compiler_commit () =
       let is_compiler = Option.value is_compiler ~default:false in
       Current.Job.log job
       "Analysing %s: @[<v>platforms=@[%a@]@,opam_repository_commits=@[%a@]@,is_compiler=%a@,compiler_commit=%a@]"
@@ -425,11 +425,11 @@ module Examine = struct
 
   let run solver job { Key.src; _ } { Value.opam_repository_commits; platforms; is_compiler; compiler_commit; sandmark_package } =
     let package_name = package_name_from_commit src in
+    Current.Job.start job ~pool ~level:Current.Level.Average >>= fun () ->
     Current_git.with_checkout ~job src @@ fun src ->
     match sandmark_package with
     | None -> Analysis.of_dir ~solver ~platforms ~opam_repository_commits ~job ~package_name ~is_compiler ?compiler_commit src
     | Some package_name ->
-      Current.Job.start job ~pool ~level:Current.Level.Harmless >>= fun () ->
       Analysis.of_dir_sandmark ~platforms ~opam_repository_commits ~job ~package_name ~is_compiler ?compiler_commit ()
 
   let pp f (k, v) = Fmt.pf f "Analyse %s %s" (Key.digest k) (Value.digest v)

--- a/lib/analyse.ml
+++ b/lib/analyse.ml
@@ -425,7 +425,6 @@ module Examine = struct
 
   let run solver job { Key.src; _ } { Value.opam_repository_commits; platforms; is_compiler; compiler_commit; sandmark_package } =
     let package_name = package_name_from_commit src in
-    (* Current.Job.start job ~pool ~level:Current.Level.Harmless >>= fun () -> *)
     Current_git.with_checkout ~job src @@ fun src ->
     match sandmark_package with
     | None -> Analysis.of_dir ~solver ~platforms ~opam_repository_commits ~job ~package_name ~is_compiler ?compiler_commit src

--- a/lib/analyse.ml
+++ b/lib/analyse.ml
@@ -40,7 +40,7 @@ let read_file ~max_len path =
 
 (* A logging service that logs to [job]. *)
 let job_log job =
-  let module X = Ocaml_multicore_ci_api.Raw.Service.Log in
+  let module X = Ocaml_multicore_ci_api.Raw.Solve.Service.Log in
   X.local @@ object
     inherit X.service
 
@@ -77,6 +77,7 @@ let remove_dev_selections ~opam_files = function
     `Opam_build (remove_dev_selections_from_opam_build ~opam_files selections)
   | `Opam_monorepo _ as x -> x
   | `Not_opam _ as x -> x
+
 module Analysis = struct
   type t = {
     opam_files : string list;

--- a/lib/analyse.ml
+++ b/lib/analyse.ml
@@ -268,6 +268,7 @@ module Analysis = struct
       }
     in
     Capnp_rpc_lwt.Capability.with_ref (job_log job) @@ fun log ->
+    Backend_solver.ci solver >>= fun solver ->
     Ocaml_multicore_ci_api.Solver.solve solver request ~log >|= function
     | Ok [] -> Fmt.error_msg "No solution found for any supported platform"
     | Ok x -> Ok (List.map Selection.of_worker x)
@@ -364,7 +365,7 @@ let platforms_to_yojson platforms =
   `List (List.map platform_to_yojson platforms)
 
 module Examine = struct
-  type t = Ocaml_multicore_ci_api.Solver.t
+  type t = Backend_solver.t
 
   module Key = struct
     type t = {

--- a/lib/analyse.mli
+++ b/lib/analyse.mli
@@ -11,7 +11,7 @@ module Analysis : sig
     ]
 
   val of_dir :
-    solver:Ocaml_multicore_ci_api.Solver.t ->
+    solver: Backend_solver.t ->
     job:Current.Job.t ->
     platforms:(Variant.t * Ocaml_multicore_ci_api.Worker.Vars.t) list ->
     opam_repository_commits:Current_git.Commit_id.t list ->
@@ -25,7 +25,7 @@ end
 val examine :
   ?label:string ->
   ?sandmark_package: string ->
-  solver:Ocaml_multicore_ci_api.Solver.t ->
+  solver: Backend_solver.t ->
   platforms:Platform.t list Current.t ->
   opam_repository_commits:Current_git.Commit_id.t list Current.t ->
   is_compiler:bool ->
@@ -39,7 +39,7 @@ val examine :
 val examine_with_compiler :
   ?label:string ->
   ?sandmark_package:string ->
-  solver:Ocaml_multicore_ci_api.Solver.t ->
+  solver: Backend_solver.t ->
   platforms:Platform.t list Current.t ->
   opam_repository_commits:Current_git.Commit_id.t list Current.t ->
   compiler_commit:Current_git.Commit_id.t Current.t ->

--- a/lib/backend_solver.ml
+++ b/lib/backend_solver.ml
@@ -1,70 +1,59 @@
-open Capnp_rpc_lwt
 open Lwt.Infix
 
-let retry_delay = 5.0   (* Time to wait after a failed connection before retrying. *)
+let ( >>!= ) = Lwt_result.bind
 
-module Metrics = struct
-  open Prometheus
+type t = [`Remote of Current_ocluster.Connection.t | `Local of Ocaml_multicore_ci_api.Solver.t Lwt.t]
 
-  let namespace = "ocaml_multicore_ci"
-  let subsystem = "solver"
+let pool = "solver-pool"
 
-  let backend_down =
-    let help = "Whether the connection to the Solver is down" in
-    Gauge.v ~help ~namespace ~subsystem "sovler_down"
-end
+let solve_to_custom req builder =
+  let params =
+    Yojson.Safe.to_string
+    @@ Ocaml_multicore_ci_api.Worker.Solve_request.to_yojson req
+  in
+  let builder =
+    Ocaml_multicore_ci_api.Raw.Builder.Solver.Solve.Params.init_pointer builder
+  in
+  Ocaml_multicore_ci_api.Raw.Builder.Solver.Solve.Params.request_set builder params
 
-type conn_remote = {
-  sr : Ocaml_multicore_ci_api.Solver.X.t Sturdy_ref.t;
-  mutable ci : Ocaml_multicore_ci_api.Solver.t Lwt.t;
-  mutable last_failed : float;
-}
+let remote_solve con job request =
+  let action =
+    Cluster_api.Submission.custom_build
+    @@ Cluster_api.Custom.v ~kind:"solve"
+    @@ solve_to_custom request
+  in
+  let build_pool =
+    Current_ocluster.Connection.pool ~job ~pool ~action ~cache_hint:"" con
+  in
+  Current.Job.start_with ~pool:build_pool job ~level:Current.Level.Average
+  >>= fun build_job ->
+  Capnp_rpc_lwt.Capability.with_ref build_job
+    (Current_ocluster.Connection.run_job ~job)
 
-type t = [`Remote of conn_remote | `Local of Ocaml_multicore_ci_api.Solver.t Lwt.t]
-
-let rec reconnect t =
-  Prometheus.Gauge.set Metrics.backend_down 1.0;
-  let now = Unix.gettimeofday () in
-  let delay = t.last_failed +. retry_delay -. now in
-  t.last_failed <- now;
-  Lwt.async (fun () ->
-      begin if delay > 0.0 then Lwt_unix.sleep delay else Lwt.return_unit end
-      >>= fun () ->
-      Log.info (fun f -> f "Reconnecting to the Solver");
-      let ci =
-        try Sturdy_ref.connect_exn t.sr
-        with ex -> Lwt.fail ex    (* (just in case) *)
-      in
-      t.ci <- ci;
-      monitor t;
-      Lwt.return_unit
-    )
-and monitor t =
-  Lwt.on_any t.ci
-    (fun ci ->
-       (* Connected OK - now watch for failure. *)
-       Prometheus.Gauge.set Metrics.backend_down 0.0;
-       ci |> Capability.when_broken @@ fun ex ->
-       Log.warn (fun f -> f "Lost connection to the Solver: %a" Capnp_rpc.Exception.pp ex);
-       reconnect t
-    )
-    (fun ex ->
-       (* Failed to connect. *)
-       Log.warn (fun f -> f "Failed to connect to the Solver: %a" Fmt.exn ex);
-       reconnect t
-    )
-
-let make sr : t =
-    let ci = Sturdy_ref.connect_exn sr in
-    let t = { sr; ci; last_failed = 0.0 } in
-    Prometheus.Gauge.set Metrics.backend_down 1.0;
-    monitor t;
-    `Remote t
-
-let local ?solver_dir () =
+let local ?solver_dir () : t =
   `Local (Lwt.return (Solver_pool.spawn_local ?solver_dir ()))
 
-let ci t =
-  match t with
-  | `Remote t -> t.ci
-  | `Local t  -> t
+let solve t job request ~log = match t with
+  | `Local ci ->
+    ci >>= fun solver -> Ocaml_multicore_ci_api.Solver.solve solver request ~log
+  | `Remote con ->
+    remote_solve con job request >>!= fun response ->
+    match
+      Ocaml_multicore_ci_api.Worker.Solve_response.of_yojson
+        (Yojson.Safe.from_string response)
+    with
+    | Ok x -> Lwt.return x
+    | Error ex -> failwith ex
+
+let create ?solver_dir uri =
+  match uri with
+  | None    -> local ?solver_dir ()
+  | Some ur ->
+    let vat = Capnp_rpc_unix.client_only_vat () in
+    let sr = Capnp_rpc_unix.Vat.import_exn vat ur in
+    `Remote (Current_ocluster.Connection.create sr)
+
+let local_ci t : Ocaml_multicore_ci_api.Solver.t Lwt.t = match t with
+  | `Local ci -> ci
+  | `Remote _ -> Fmt.failwith "Not a local solver"
+

--- a/lib/backend_solver.ml
+++ b/lib/backend_solver.ml
@@ -1,0 +1,70 @@
+open Capnp_rpc_lwt
+open Lwt.Infix
+
+let retry_delay = 5.0   (* Time to wait after a failed connection before retrying. *)
+
+module Metrics = struct
+  open Prometheus
+
+  let namespace = "ocaml_multicore_ci"
+  let subsystem = "solver"
+
+  let backend_down =
+    let help = "Whether the connection to the Solver is down" in
+    Gauge.v ~help ~namespace ~subsystem "sovler_down"
+end
+
+type conn_remote = {
+  sr : Ocaml_multicore_ci_api.Solver.X.t Sturdy_ref.t;
+  mutable ci : Ocaml_multicore_ci_api.Solver.t Lwt.t;
+  mutable last_failed : float;
+}
+
+type t = [`Remote of conn_remote | `Local of Ocaml_multicore_ci_api.Solver.t Lwt.t]
+
+let rec reconnect t =
+  Prometheus.Gauge.set Metrics.backend_down 1.0;
+  let now = Unix.gettimeofday () in
+  let delay = t.last_failed +. retry_delay -. now in
+  t.last_failed <- now;
+  Lwt.async (fun () ->
+      begin if delay > 0.0 then Lwt_unix.sleep delay else Lwt.return_unit end
+      >>= fun () ->
+      Log.info (fun f -> f "Reconnecting to the Solver");
+      let ci =
+        try Sturdy_ref.connect_exn t.sr
+        with ex -> Lwt.fail ex    (* (just in case) *)
+      in
+      t.ci <- ci;
+      monitor t;
+      Lwt.return_unit
+    )
+and monitor t =
+  Lwt.on_any t.ci
+    (fun ci ->
+       (* Connected OK - now watch for failure. *)
+       Prometheus.Gauge.set Metrics.backend_down 0.0;
+       ci |> Capability.when_broken @@ fun ex ->
+       Log.warn (fun f -> f "Lost connection to the Solver: %a" Capnp_rpc.Exception.pp ex);
+       reconnect t
+    )
+    (fun ex ->
+       (* Failed to connect. *)
+       Log.warn (fun f -> f "Failed to connect to the Solver: %a" Fmt.exn ex);
+       reconnect t
+    )
+
+let make sr : t =
+    let ci = Sturdy_ref.connect_exn sr in
+    let t = { sr; ci; last_failed = 0.0 } in
+    Prometheus.Gauge.set Metrics.backend_down 1.0;
+    monitor t;
+    `Remote t
+
+let local ?solver_dir () =
+  `Local (Lwt.return (Solver_pool.spawn_local ?solver_dir ()))
+
+let ci t =
+  match t with
+  | `Remote t -> t.ci
+  | `Local t  -> t

--- a/lib/backend_solver.ml
+++ b/lib/backend_solver.ml
@@ -4,7 +4,7 @@ let ( >>!= ) = Lwt_result.bind
 
 type t = [`Remote of Current_ocluster.Connection.t | `Local of Ocaml_multicore_ci_api.Solver.t Lwt.t]
 
-let pool = "solver-pool"
+let pool = "solver"
 
 let solve_to_custom req builder =
   let params =
@@ -56,4 +56,3 @@ let create ?solver_dir uri =
 let local_ci t : Ocaml_multicore_ci_api.Solver.t Lwt.t = match t with
   | `Local ci -> ci
   | `Remote _ -> Fmt.failwith "Not a local solver"
-

--- a/lib/backend_solver.ml
+++ b/lib/backend_solver.ml
@@ -12,9 +12,9 @@ let solve_to_custom req builder =
     @@ Ocaml_multicore_ci_api.Worker.Solve_request.to_yojson req
   in
   let builder =
-    Ocaml_multicore_ci_api.Raw.Builder.Solver.Solve.Params.init_pointer builder
+    Ocaml_multicore_ci_api.Raw.Solve.Builder.Solver.Solve.Params.init_pointer builder
   in
-  Ocaml_multicore_ci_api.Raw.Builder.Solver.Solve.Params.request_set builder params
+  Ocaml_multicore_ci_api.Raw.Solve.Builder.Solver.Solve.Params.request_set builder params
 
 let remote_solve con job request =
   let action =

--- a/lib/backend_solver.mli
+++ b/lib/backend_solver.mli
@@ -1,0 +1,10 @@
+open Capnp_rpc_lwt
+
+type t
+
+val make : Ocaml_multicore_ci_api.Solver.X.t Sturdy_ref.t -> t
+
+val local : ?solver_dir:string -> unit -> t
+
+val ci : t -> Ocaml_multicore_ci_api.Solver.t Lwt.t
+

--- a/lib/backend_solver.mli
+++ b/lib/backend_solver.mli
@@ -1,10 +1,14 @@
-open Capnp_rpc_lwt
-
 type t
 
-val make : Ocaml_multicore_ci_api.Solver.X.t Sturdy_ref.t -> t
+val create : ?solver_dir:string -> Uri.t option -> t
 
 val local : ?solver_dir:string -> unit -> t
 
-val ci : t -> Ocaml_multicore_ci_api.Solver.t Lwt.t
+val local_ci : t -> Ocaml_multicore_ci_api.Solver.t Lwt.t
 
+val solve :
+  t ->
+  Current.Job.t ->
+  Ocaml_multicore_ci_api.Worker.Solve_request.t ->
+  log :Ocaml_multicore_ci_api.Raw.Builder.Log.t Capnp_rpc_lwt.Capability.t ->
+  Ocaml_multicore_ci_api.Worker.Solve_response.t Lwt.t

--- a/lib/backend_solver.mli
+++ b/lib/backend_solver.mli
@@ -10,5 +10,5 @@ val solve :
   t ->
   Current.Job.t ->
   Ocaml_multicore_ci_api.Worker.Solve_request.t ->
-  log :Ocaml_multicore_ci_api.Raw.Builder.Log.t Capnp_rpc_lwt.Capability.t ->
+  log :Ocaml_multicore_ci_api.Raw.Solve.Builder.Log.t Capnp_rpc_lwt.Capability.t ->
   Ocaml_multicore_ci_api.Worker.Solve_response.t Lwt.t

--- a/lib/dune
+++ b/lib/dune
@@ -1,6 +1,19 @@
 (library
   (name ocaml_multicore_ci)
   (preprocess (pps ppx_deriving.std ppx_deriving_yojson))
-  (libraries logs current current_docker current_github current.term ocaml-multicore-ci-api str capnp-rpc-unix
-             current.cache ppx_deriving_yojson.runtime ocaml-version opam-0install
-             current_ocluster ocluster-api obuilder-spec))
+  (libraries
+    logs
+    current
+    current_docker
+    current_github
+    current.term
+    ocaml-multicore-ci-api
+    str
+    capnp-rpc-unix
+    current.cache
+    ppx_deriving_yojson.runtime
+    ocaml-version
+    opam-0install
+    current_ocluster
+    ocluster-api
+    obuilder-spec))

--- a/lib/log.ml
+++ b/lib/log.ml
@@ -1,0 +1,2 @@
+let src = Logs.Src.create "ocaml_multicore_ci_solver" ~doc:"ocaml-multicore-ci solver backend "
+include (val Logs.src_log src : Logs.LOG)

--- a/lib/opam_version.ml
+++ b/lib/opam_version.ml
@@ -1,0 +1,11 @@
+type t = [ `V2_0 | `V2_1 ] [@@deriving ord, yojson, eq]
+
+let to_string = function `V2_0 -> "2.0" | `V2_1 -> "2.1"
+let to_string_with_patch = function `V2_0 -> "2.0.10" | `V2_1 -> "2.1.2"
+let pp = Fmt.of_to_string to_string
+let default = `V2_0
+
+let of_string = function
+  | "2.0" -> Ok `V2_0
+  | "2.1" -> Ok `V2_1
+  | s -> Error (`Msg (s ^ ": invalid opam version"))

--- a/lib/opam_version.mli
+++ b/lib/opam_version.mli
@@ -1,0 +1,7 @@
+type t = [ `V2_0 | `V2_1 ] [@@deriving ord, yojson, eq]
+
+val pp : t Fmt.t
+val to_string : t -> string
+val to_string_with_patch : t -> string
+val default : t
+val of_string : string -> (t, [ `Msg of string ]) result

--- a/lib/platform.ml
+++ b/lib/platform.ml
@@ -71,7 +71,8 @@ module Query = struct
       "os": "%%{os}%%",
       "os_family": "%%{os-family}%%",
       "os_distribution": "%%{os-distribution}%%",
-      "os_version": "%%{os-version}%%"
+      "os_version": "%%{os-version}%%",
+      "opam_version": "%%{opam-version}%%"
     }
   |} arch
 
@@ -128,24 +129,34 @@ let query builder ~variant ~host_image image =
   let docker_context = builder.Builder.docker_context in
   QC.run Query.No_context { Query.Key.docker_context; variant } { Query.Value.image; host_image }
 
-let get ~arch ~label ~builder ~pool ~distro ~ocaml_version ~host_base base =
-  match Variant.v ~arch ~distro ~ocaml_version with
+let get ~arch ~label ~builder ~pool ~distro ~ocaml_version ~host_base
+    ~opam_version base =
+  match Variant.v ~arch ~distro ~ocaml_version ~opam_version with
   | Error (`Msg m) -> Current.fail m
   | Ok variant ->
-  let+ { Query.Outcome.vars; image } = query builder ~variant ~host_image:host_base base in
+  let+ { Query.Outcome.vars; image } =
+    query builder ~variant ~host_image:host_base base
+  in
   (* It would be better to run the opam query on the platform itself, but for
      now we run everything on x86_64 and then assume that the other
      architectures are the same except for the arch flag. *)
-  let vars = { vars with arch = Ocaml_version.to_opam_arch arch } in
+  let vars = {
+    vars with
+    arch = Ocaml_version.to_opam_arch arch;
+    opam_version = Opam_version.to_string_with_patch opam_version;
+  }
+  in
   let base = Raw.Image.of_hash image in
   { label; builder; pool; variant; base; vars }
 
-let pull ~arch ~schedule ~builder ~distro ~ocaml_version =
-  match Variant.v ~arch ~distro ~ocaml_version with
+let pull ~arch ~schedule ~builder ~distro ~ocaml_version ~opam_version =
+  match Variant.v ~arch ~distro ~ocaml_version ~opam_version with
   | Error (`Msg m) -> Current.fail m
   | Ok variant ->
   let archl = Ocaml_version.to_opam_arch arch in
-  Current.component "pull@,%s %a %s" distro Ocaml_version.pp ocaml_version archl |>
-  let> () = Current.return () in
-  let tag = Variant.docker_tag variant in
-  Builder.pull ~schedule ~arch builder @@ "ocaml/opam:" ^ tag
+  let opam_version = Opam_version.to_string opam_version in
+  Current.component "pull@,%s %a %s opam-%s" distro Ocaml_version.pp
+    ocaml_version archl opam_version
+  |> let> () = Current.return () in
+     let tag = Variant.docker_tag variant in
+     Builder.pull ~schedule ~arch builder @@ "ocaml/opam:" ^ tag

--- a/lib/platform.mli
+++ b/lib/platform.mli
@@ -25,6 +25,7 @@ val get :
   distro:string ->
   ocaml_version:Ocaml_version.t ->
   host_base:Current_docker.Raw.Image.t Current.t ->
+  opam_version:Opam_version.t ->
   Current_docker.Raw.Image.t Current.t ->
   t Current.t
 (** [get ~label ~builder ~variant ~host_base base] creates a [t] by getting the opam variables from [host_base]
@@ -36,5 +37,6 @@ val pull :
   builder:Builder.t ->
   distro:string ->
   ocaml_version:Ocaml_version.t ->
+  opam_version:Opam_version.t ->
   Current_docker.Raw.Image.t Current.t
 (** [pull ~schedule ~builder ~distro ~ocaml_version] pulls "ocaml/opam:{distro}-ocaml-{version}" on [schedule]. *)

--- a/lib/variant.ml
+++ b/lib/variant.ml
@@ -1,72 +1,96 @@
 module Ocaml_version = struct
   include Ocaml_version
+
   let arch_to_yojson arch = `String (string_of_arch arch)
+
   let arch_of_yojson j =
     match j with
-    |`String a -> begin
-       match arch_of_string a with
-       | Ok v -> Ok v
-       | Error _ -> Error ("unknown arch " ^ a)
-     end
+    | `String a -> (
+        match arch_of_string a with
+        | Ok v -> Ok v
+        | Error _ -> Error ("unknown arch " ^ a))
     | _ -> Error "unknown json type for arch"
 
   let compare_arch = Stdlib.compare
-  let equal_arch = (=)
+  let equal_arch = ( = )
   let to_yojson t = `String (to_string t)
+
   let of_yojson j =
     match j with
-    |`String a -> begin
-      match of_string a with
-      | Ok v -> Ok v
-      | Error _ -> Error ("unknown ocaml version " ^ a)
-    end
+    | `String a -> (
+        match of_string a with
+        | Ok v -> Ok v
+        | Error _ -> Error ("unknown ocaml version " ^ a))
     | _ -> Error "unknown json for ocaml version"
 end
 
 type t = {
-  distro: string;
-  ocaml_version: Ocaml_version.t;
-  arch: Ocaml_version.arch;
-} [@@deriving yojson, ord, eq]
+  distro : string;
+  ocaml_version : Ocaml_version.t;
+  arch : Ocaml_version.arch;
+  opam_version : Opam_version.t;
+}
+[@@deriving yojson, ord, eq]
 
-let v ~arch ~distro ~ocaml_version =
+let v ~arch ~distro ~ocaml_version ~opam_version =
   (* Just check we understand all the variants first *)
   match Ocaml_version.Configure_options.of_t ocaml_version with
-  | Ok _ -> Ok { arch; distro; ocaml_version }
+  | Ok _ -> Ok { arch; distro; ocaml_version; opam_version }
   | Error e -> Error e
 
 let arch { arch; _ } = arch
 let distro { distro; _ } = distro
 let ocaml_version { ocaml_version; _ } = ocaml_version
 let with_ocaml_version ocaml_version t = { t with ocaml_version }
+let opam_version t = t.opam_version
 
 let id { distro; ocaml_version; _ } =
   Fmt.str "%s-%a" distro Ocaml_version.pp ocaml_version
 
 let docker_tag { distro; ocaml_version; _ } =
-  Fmt.str "%s-ocaml-%s" distro (Ocaml_version.to_string ~sep:'-' ocaml_version
-    |> String.map (function | '+' -> '-' | x -> x))
+  Fmt.str "%s-ocaml-%s" distro
+    (Ocaml_version.to_string ~sep:'-' ocaml_version
+    |> String.map (function '+' -> '-' | x -> x))
 
 let id_of_string s =
   match Astring.String.cut ~rev:true ~sep:"-" s with
-  | Some (distro, ov) -> Some (distro, (Ocaml_version.of_string_exn ov))
+  | Some (distro, ov) -> Some (distro, Ocaml_version.of_string_exn ov)
   | None -> None
 
 let pp f t =
-  Fmt.pf f "%s%s" (id t)
+  Fmt.pf f "%s%s%s" (id t)
     (match t.arch with
-     | `X86_64 -> ""
-     | a -> "_" ^ (Ocaml_version.to_opam_arch a))
+    | `X86_64 -> ""
+    | a -> "_" ^ Ocaml_version.to_opam_arch a)
+    (match t.opam_version with
+    | `V2_0 -> ""
+    | v -> "_opam-" ^ Opam_version.to_string v)
 
-let to_string =
-  Fmt.str "%a" pp
+let to_string = Fmt.str "%a" pp
+let err_variant id = failwith ("internal error: unknown variant " ^ id)
+let err_arch a = failwith ("internal error: unknown arch " ^ a)
+let err_opam_version id = failwith ("internal error: unknown opam version " ^ id)
+
+let arch_of_string a =
+  match Ocaml_version.of_opam_arch a with Some a -> a | None -> err_arch a
+
+let opam_version_of_string v =
+  match Opam_version.of_string v with
+  | Ok v -> v
+  | Error _ -> err_opam_version v
 
 let of_string s =
+  let s, opam_version =
+    match Astring.String.cut ~rev:true ~sep:"_opam-" s with
+    | None -> (s, Opam_version.default)
+    | Some (s, v) -> (s, opam_version_of_string v)
+  in
   let id, arch =
-   match Astring.String.cut ~sep:"_" s with
-   | None -> s, `X86_64
-   | Some (s, a) -> s, (Ocaml_version.of_opam_arch a |> Option.value ~default:`X86_64)
+    match Astring.String.cut ~sep:"_" s with
+    | None -> (s, `X86_64)
+    | Some (id, a) -> (id, arch_of_string a)
   in
   match id_of_string id with
-  | None -> raise (Failure ("internal error: unknown variant " ^ id))
-  | Some (distro, ocaml_version) -> { arch; distro; ocaml_version }
+  | None -> err_variant id
+  | Some (distro, ocaml_version) ->
+      { arch; distro; ocaml_version; opam_version }

--- a/lib/variant.mli
+++ b/lib/variant.mli
@@ -1,17 +1,19 @@
-type t [@@deriving eq,ord,yojson]
+type t [@@deriving eq, ord, yojson]
 
-val v : arch:Ocaml_version.arch ->
-        distro:string -> ocaml_version:Ocaml_version.t ->
-        (t, [> `Msg of string ]) result
+val v :
+  arch:Ocaml_version.arch ->
+  distro:string ->
+  ocaml_version:Ocaml_version.t ->
+  opam_version:Opam_version.t ->
+  (t, [> `Msg of string ]) result
 
 val arch : t -> Ocaml_version.arch
 val distro : t -> string
 val ocaml_version : t -> Ocaml_version.t
 val with_ocaml_version : Ocaml_version.t -> t -> t
-
+val opam_version : t -> Opam_version.t
 val id : t -> string
 val docker_tag : t -> string
 val pp : t Fmt.t
-
 val to_string : t -> string
 val of_string : string -> t

--- a/service/api_impl.ml
+++ b/service/api_impl.ml
@@ -1,5 +1,5 @@
 module Rpc = Current_rpc.Impl(Current)
-module Raw = Ocaml_multicore_ci_api.Raw
+module Raw = Ocaml_multicore_ci_api.Raw.Build
 
 module String_map = Map.Make(String)
 module Index = Ocaml_multicore_ci.Index

--- a/service/api_impl.mli
+++ b/service/api_impl.mli
@@ -1,1 +1,1 @@
-val make_ci : engine:Current.Engine.t -> Ocaml_multicore_ci_api.Raw.Service.CI.t Capnp_rpc_lwt.Capability.t
+val make_ci : engine:Current.Engine.t -> Ocaml_multicore_ci_api.Raw.Build.Service.CI.t Capnp_rpc_lwt.Capability.t

--- a/service/conf.ml
+++ b/service/conf.ml
@@ -59,6 +59,7 @@ type platform = {
   distro : string;
   ocaml_version : OV.t;
   arch: OV.arch;
+  opam_version: Ocaml_multicore_ci.Opam_version.t
 }
 
 let pool_of_arch : OV.arch -> string = function
@@ -67,9 +68,16 @@ let pool_of_arch : OV.arch -> string = function
 | `Ppc64le -> "linux-ppc64"
 | `S390x -> assert false
 
-let platforms =
+let platforms opam_version =
   let v ?(arch=`X86_64) label distro ocaml_version =
-    { arch; label; builder = Builders.local; pool = pool_of_arch arch; distro; ocaml_version }
+    { arch;
+      label;
+      builder = Builders.local;
+      pool = pool_of_arch arch;
+      distro;
+      ocaml_version;
+      opam_version;
+    }
   in
   let master_distro = (DD.resolve_alias DD.master_distro :> DD.t) in
   let make_distro distro =

--- a/service/local.ml
+++ b/service/local.ml
@@ -1,6 +1,6 @@
 (* Utility program for testing the CI pipeline on a local repository. *)
 
-let solver = Ocaml_multicore_ci.Solver_pool.spawn_local ()
+let solver = Ocaml_multicore_ci.Backend_solver.local ()
 
 let () =
   Unix.putenv "DOCKER_BUILDKIT" "1";

--- a/service/main.ml
+++ b/service/main.ml
@@ -138,7 +138,7 @@ let solver_service =
   Arg.value @@
   Arg.opt Arg.(some Capnp_rpc_unix.sturdy_uri) None @@
   Arg.info
-    ~doc:"The solver.cap file for the sovler scheduler service"
+    ~doc:"The solver.cap file for the solver scheduler service"
     ~docv:"FILE"
     ["solver-service"]
 

--- a/service/main.ml
+++ b/service/main.ml
@@ -40,7 +40,12 @@ module Metrics = struct
     Gauge.set (master "active") (float_of_int active)
 end
 
-let solver = Ocaml_multicore_ci.Solver_pool.spawn_local ()
+let solver  = function
+  | None     -> Ocaml_multicore_ci.Backend_solver.local ()
+  | Some uri ->
+    let vat = Capnp_rpc_unix.client_only_vat () in
+    let sr = Capnp_rpc_unix.Vat.import_exn vat uri in
+    Ocaml_multicore_ci.Backend_solver.make sr
 
 let () =
   Prometheus_unix.Logging.init ();
@@ -86,11 +91,12 @@ let has_role user = function
            ) -> true
     | _ -> false
 
-let main config mode app capnp_address github_auth submission_uri : ('a, [`Msg of string]) result =
+let main config mode app capnp_address github_auth submission_uri solver_uri : ('a, [`Msg of string]) result =
   Lwt_main.run begin
     run_capnp capnp_address >>= fun (vat, rpc_engine_resolver) ->
     let ocluster = Option.map (Capnp_rpc_unix.Vat.import_exn vat) submission_uri in
     let confs = Conf.configs in
+    let solver = solver solver_uri in
     let engine = Current.Engine.create ~config (Pipeline.v ?ocluster ~solver ~confs) in
     rpc_engine_resolver |> Option.iter (fun r -> Capability.resolve_ok r (Api_impl.make_ci ~engine));
     let authn = Option.map Current_github.Auth.make_login_uri github_auth in
@@ -135,6 +141,14 @@ let submission_service =
     ~docv:"FILE"
     ["submission-service"]
 
+let solver_service =
+  Arg.value @@
+  Arg.opt Arg.(some Capnp_rpc_unix.sturdy_uri) None @@
+  Arg.info
+    ~doc:"The solver.cap file for the sovler scheduler service"
+    ~docv:"FILE"
+    ["solver-service"]
+
 let github_app_id =
   Arg.required @@
   Arg.opt Arg.(some string) None @@
@@ -151,7 +165,7 @@ let cmd ~with_github =
     term_result (
       const main $ Current.Config.cmdliner $ Current_web.cmdliner $
       gh_cmd $
-      capnp_address $ Current_github.Auth.cmdliner $ submission_service)) in
+      capnp_address $ Current_github.Auth.cmdliner $ submission_service $ solver_service)) in
   let info = Cmd.info "ocaml-multicore-ci" ~doc in
   Cmd.v info term
 

--- a/service/pipeline.ml
+++ b/service/pipeline.ml
@@ -31,16 +31,17 @@ let gref_to_version gref =
 
 let platforms =
   let schedule = monthly in
-  let v { Conf.label; builder; pool; distro; ocaml_version; arch } =
-    let base = Platform.pull ~arch ~schedule ~builder ~distro ~ocaml_version in
+  let v { Conf.label; builder; pool; distro; ocaml_version; arch; opam_version} =
+    let base = Platform.pull ~arch ~schedule ~builder ~distro ~ocaml_version ~opam_version in
     let host_base =
       match arch with
       | `X86_64 -> base
-      | _ -> Platform.pull ~arch:`X86_64 ~schedule ~builder ~distro ~ocaml_version
+      | _ -> Platform.pull ~arch:`X86_64 ~schedule ~builder ~distro ~ocaml_version ~opam_version
     in
-    Platform.get ~arch ~label ~builder ~pool ~distro ~ocaml_version ~host_base base
+    Platform.get ~arch ~label ~builder ~pool ~distro ~ocaml_version ~host_base ~opam_version base
   in
-  Current.list_seq (List.map v Conf.platforms)
+  let v2_1 = Conf.platforms `V2_1 in
+  Current.list_seq (List.map v v2_1)
 
 let get_job_id x =
   let+ md = Current.Analysis.metadata x in

--- a/service/pipeline.mli
+++ b/service/pipeline.mli
@@ -1,15 +1,15 @@
-val local_test : ?label: string -> solver:Ocaml_multicore_ci_api.Solver.t -> Current_git.Local.t -> unit -> unit Current.t
+val local_test : ?label: string -> solver:Ocaml_multicore_ci.Backend_solver.t -> Current_git.Local.t -> unit -> unit Current.t
 (** [local_test ~solver repo] is a pipeline that tests local repository [repo] as the CI would. *)
 
-val local_test_multiple : solver:Ocaml_multicore_ci_api.Solver.t -> Current_git.Local.t list -> unit -> unit Current.t
+val local_test_multiple : solver:Ocaml_multicore_ci.Backend_solver.t -> Current_git.Local.t list -> unit -> unit Current.t
 (** [local_test_multiple ~solver repos] runs multiple local repository tests in parallel. *)
 
-val local_test_fixed : solver:Ocaml_multicore_ci_api.Solver.t -> Conf.conf list -> unit -> unit Current.t
+val local_test_fixed : solver:Ocaml_multicore_ci.Backend_solver.t -> Conf.conf list -> unit -> unit Current.t
 (** [local_test_fixed ~solver] runs local builds on the fixed set of configured repositories. *)
 
 val v :
   ?ocluster:Cluster_api.Raw.Client.Submission.t Capnp_rpc_lwt.Sturdy_ref.t ->
-  solver:Ocaml_multicore_ci_api.Solver.t ->
+  solver:Ocaml_multicore_ci.Backend_solver.t ->
   confs:(Conf.conf list) ->
   unit -> unit Current.t
 (** The main ocaml-multicore-ci pipeline. Tests everything configured for GitHub application [app]. *)

--- a/solver/service.ml
+++ b/solver/service.ml
@@ -134,7 +134,7 @@ let v ~n_workers ~create_worker =
     Epoch.create ~n_workers ~create_worker commits
   in
   let t = Epoch_lock.v ~create ~dispose:Epoch.dispose () in
-  let module X = Ocaml_multicore_ci_api.Raw.Service.Solver in
+  let module X = Ocaml_multicore_ci_api.Raw.Solve.Service.Solver in
   Lwt.return @@ X.local @@ object
     inherit X.service
 

--- a/test/test_analyse.ml
+++ b/test/test_analyse.ml
@@ -32,7 +32,7 @@ module Analysis = struct
   let of_dir ~switch ~job ~package_name ~platforms ~solver_dir ~opam_repository_commits d =
     let solver = Ocaml_multicore_ci.Backend_solver.local ~solver_dir () in
     Lwt_switch.add_hook (Some switch) (fun () ->
-        Ocaml_multicore_ci.Backend_solver.ci solver >>= fun solver ->
+        Ocaml_multicore_ci.Backend_solver.local_ci solver >>= fun solver ->
         Capnp_rpc_lwt.Capability.dec_ref solver;
         Lwt.return_unit
       );

--- a/test/test_analyse.ml
+++ b/test/test_analyse.ml
@@ -30,8 +30,9 @@ module Analysis = struct
 
 
   let of_dir ~switch ~job ~package_name ~platforms ~solver_dir ~opam_repository_commits d =
-    let solver = Ocaml_multicore_ci.Solver_pool.spawn_local ~solver_dir () in
+    let solver = Ocaml_multicore_ci.Backend_solver.local ~solver_dir () in
     Lwt_switch.add_hook (Some switch) (fun () ->
+        Ocaml_multicore_ci.Backend_solver.ci solver >>= fun solver ->
         Capnp_rpc_lwt.Capability.dec_ref solver;
         Lwt.return_unit
       );

--- a/test/test_platforms.ml
+++ b/test/test_platforms.ml
@@ -5,13 +5,18 @@ let debian_10_vars ocaml_package ocaml_version =
     os_family = "debian";
     os_distribution = "debian";
     os_version = "10";
+    opam_version = "2.0.10";
     ocaml_package;
     ocaml_version
   }
 
 let var distro ov =
-  Ocaml_multicore_ci.Variant.v ~arch:`X86_64 ~distro ~ocaml_version:(Ocaml_version.of_string_exn ov) |>
-  function Ok v -> v | Error (`Msg m) -> failwith m
+  Ocaml_multicore_ci.Variant.v ~arch:`X86_64 ~distro
+    ~ocaml_version:(Ocaml_version.of_string_exn ov)
+    ~opam_version:`V2_0
+  |> function
+  | Ok v -> v
+  | Error (`Msg m) -> failwith m
 
 let v = [
   var "debian-10" "4.10", debian_10_vars "ocaml" "4.10.0";

--- a/web-ui/backend.ml
+++ b/web-ui/backend.ml
@@ -15,7 +15,7 @@ module Metrics = struct
 end
 
 type t = {
-  sr : Ocaml_multicore_ci_api.Raw.Client.CI.t Sturdy_ref.t;
+  sr : Ocaml_multicore_ci_api.Raw.Build.Client.CI.t Sturdy_ref.t;
   mutable ci : Ocaml_multicore_ci_api.Client.CI.t Lwt.t;
   mutable last_failed : float;
 }

--- a/web-ui/backend.mli
+++ b/web-ui/backend.mli
@@ -2,6 +2,6 @@ open Capnp_rpc_lwt
 
 type t
 
-val make : Ocaml_multicore_ci_api.Raw.Client.CI.t Sturdy_ref.t -> t
+val make : Ocaml_multicore_ci_api.Raw.Build.Client.CI.t Sturdy_ref.t -> t
 
 val ci : t -> Ocaml_multicore_ci_api.Client.CI.t Lwt.t

--- a/web-ui/ci_graphql.ml
+++ b/web-ui/ci_graphql.ml
@@ -1,7 +1,7 @@
 open Graphql_lwt
 module Client = Ocaml_multicore_ci_api.Client
 
-type build_status = Ocaml_multicore_ci_api.Raw.Reader.BuildStatus.t
+type build_status = Ocaml_multicore_ci_api.Raw.Build.Reader.BuildStatus.t
 
 type job_state =
   | NotStarted
@@ -130,7 +130,7 @@ let config = Schema.(obj "config" ~fields:([
     ~resolve:(fun _ p -> p.Config.admin_service_uri);
 ]))
 
-let build_status = Ocaml_multicore_ci_api.Raw.Reader.BuildStatus.(Schema.(enum "build_status"
+let build_status = Ocaml_multicore_ci_api.Raw.Build.Reader.BuildStatus.(Schema.(enum "build_status"
   ~values:[
     enum_value "NotStarted" ~value:NotStarted;
     enum_value "Passed" ~value:Passed;


### PR DESCRIPTION
This PR is about adding the possibility to use [solver-service](https://github.com/patricoferris/solver-service), in order to have the solver as a service.

- [x] The first thing is to establish a direct connection with this [patch of solver-service](https://github.com/moyodiallo/solver-service/tree/ocaml-multicore-ci-solver) for testing
- [x] After, establish connection to a cluster of [solver-service](https://github.com/patricoferris/solver-service) workers.

[solver-service](https://github.com/patricoferris/solver-service)  need to be patched to match the protocol of `ocaml-multicore-ci`, which is slightly different.