### PR TITLE
Update solver-service submodule

### DIFF
--- a/lib/analyse.ml
+++ b/lib/analyse.ml
@@ -277,6 +277,7 @@ module Analysis = struct
         root_pkgs;
         pinned_pkgs;
         platforms;
+        lower_bound = false;
       }
     in
     Capnp_rpc_lwt.Capability.with_ref (job_log job) @@ fun log ->


### PR DESCRIPTION
We have added lower-bounds checking to `solver-service` (ocurrent/solver-service#34), which requires a small API change. This PR updates the submodule and corrects the structure of the API call.

The PR does not add lower-bounds checking, but this can be added later once it has been verified on `ocaml-ci`.